### PR TITLE
Add wrapper JSP tag as base template other pages can use

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # az-struts
 
-This is a tiny proof-of-concept [Struts 2](https://struts.apache.org/) app to trial Azure container deployments.
+This is a tiny [Struts 2](https://struts.apache.org/) app to trial Azure container deployments.
 
 ## Getting started
 

--- a/src/main/webapp/Hello.jsp
+++ b/src/main/webapp/Hello.jsp
@@ -1,16 +1,14 @@
-<!DOCTYPE html>
-<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
+<%@page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
+<%@taglib prefix="t" tagdir="/WEB-INF/tags" %>
 <%@ taglib prefix="s" uri="/struts-tags" %>
-<html>
-  <head>
-    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-    <title>Bonjour! — az struts</title>
-  </head>
-  <body>
-    <h1><s:property value="messageStore.message" /></h1>
-    <p>J’ai déjà dit « bonjour » <s:property value="helloCount" escapeJavaScript="true" /> fois!</p>
-    <br />
-    <p><a href="<s:url action='index'/>">Retournez à la page d’accueil.</a></p>
+<t:wrapper>
+    <jsp:attribute name="title">Bonjour! — az struts</jsp:attribute>
+    <jsp:body>
 
-  </body>
-</html>
+        <h1><s:property value="messageStore.message" /></h1>
+        <p>J’ai déjà dit « bonjour » <s:property value="helloCount" escapeJavaScript="true" /> fois!</p>
+        <br />
+        <p><a href="<s:url action='index'/>">Retournez à la page d’accueil.</a></p>
+
+    </jsp:body>
+</t:wrapper>

--- a/src/main/webapp/WEB-INF/tags/wrapper.tag
+++ b/src/main/webapp/WEB-INF/tags/wrapper.tag
@@ -17,6 +17,8 @@
     </style>
   </head>
     <body>
-      <jsp:doBody/>
+      <main>
+        <jsp:doBody/>
+      </main>
     </body>
 </html>

--- a/src/main/webapp/WEB-INF/tags/wrapper.tag
+++ b/src/main/webapp/WEB-INF/tags/wrapper.tag
@@ -1,0 +1,22 @@
+<%@tag description="Simple Wrapper Tag" pageEncoding="UTF-8"%>
+<%@attribute name="title" fragment="true" %>
+
+<!doctype html>
+<html lang="fr">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta name="viewport" content="initial-scale=1.0, width=device-width" />
+
+    <title><jsp:invoke fragment="title"/></title>
+    <style>
+        body {
+            font-size: 1.4em;
+            font-family: sans-serif;
+            word-break: break-word;
+        }
+    </style>
+  </head>
+    <body>
+      <jsp:doBody/>
+    </body>
+</html>

--- a/src/main/webapp/errors/404.jsp
+++ b/src/main/webapp/errors/404.jsp
@@ -1,15 +1,13 @@
-<!DOCTYPE html>
-<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
-<%@ taglib prefix="s" uri="/struts-tags" %>
-<html>
-  <head>
-    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-    <title>Erreur 404 — az struts</title>
-  </head>
-  <body>
-    <h1>Erreur 404!</h1>
-    <h2>Désolé, la page que vous avez demandée n’existe pas.</h2>
+<%@page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
+<%@taglib prefix="t" tagdir="/WEB-INF/tags" %>
+<t:wrapper>
+    <jsp:attribute name="title">Erreur 404 — az struts</jsp:attribute>
+    <jsp:body>
 
-    <p><a href="index.jsp">Retournez à la page d’accueil.</a></p>
-  </body>
-</html>
+        <h1>Erreur 404!</h1>
+        <p>Désolé, la page que vous avez demandée n’existe pas.</p>
+
+        <p><a href="index.jsp">Retournez à la page d’accueil.</a></p>
+
+    </jsp:body>
+</t:wrapper>

--- a/src/main/webapp/errors/Exception.jsp
+++ b/src/main/webapp/errors/Exception.jsp
@@ -1,20 +1,20 @@
-<!DOCTYPE html>
+<%@page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
+<%@taglib prefix="t" tagdir="/WEB-INF/tags" %>
 <%@ taglib prefix="s" uri="/struts-tags" %>
-<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
-<html>
-<head>
-	<meta charset="UTF-8">
-	<title>Exception — az struts</title>
-</head>
-<body>
-	<h1>L’application a rencontré un problème.</h1>
+<t:wrapper>
+    <jsp:attribute name="title">Exception — az struts</jsp:attribute>
+    <jsp:body>
 
-	<h4>Exception Name</h4>
-	<p><s:property value="exception"/></p>
-	<h4>Exception Details</h4>
-	<p><s:property value="exceptionStack"/></p>
+        <h1>L’application a rencontré un problème.</h1>
 
-	<p><a href="index.jsp">Retournez à la page d’accueil.</a></p>
-</body>
+        <h4>Exception Name</h4>
+        <p><s:property value="exception"/></p>
+        <h4>Exception Details</h4>
+        <p><s:property value="exceptionStack"/></p>
 
-</html>
+        <br />
+
+        <p><a href="index.jsp">Retournez à la page d’accueil.</a></p>
+
+    </jsp:body>
+</t:wrapper>

--- a/src/main/webapp/index.jsp
+++ b/src/main/webapp/index.jsp
@@ -1,33 +1,32 @@
-<!DOCTYPE html>
-<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
+<%@page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
+<%@taglib prefix="t" tagdir="/WEB-INF/tags" %>
 <%@ taglib prefix="s" uri="/struts-tags" %>
 <%@ taglib uri = "http://java.sun.com/jsp/jstl/core" prefix="c" %>
-<html>
-  <head>
-    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-    <title>az struts</title>
-  </head>
-  <body>
-    <h1>az struts</h1>
-    <p>Ici, c’est une toute petite application
-        <a href="https://struts.apache.org/index.html" target="_blank">Struts 2</a>
-        à expérimenter en déploiement sur
-        <a href="https://azure.microsoft.com/en-ca/overview/what-is-azure/" target="_blank">Azure</a>.
-    </p>
+<t:wrapper>
+    <jsp:attribute name="title">az struts</jsp:attribute>
+    <jsp:body>
 
-    <c:set var="sha" scope="page" value="${System.getenv('GITHUB_SHA')}"/>
-    <c:if test="${sha != null}">
-        <c:set var="shaUrl" scope="page" value="https://github.com/cds-snc/az-struts/commit/${sha}"/>
-        <p>Dernière commit: <a href="<c:url value="${shaUrl}" />" target="_blank"><c:out value="${sha}"/></a></p>
-    </c:if>
+        <h1>az struts</h1>
+        <p>Ici, c’est une toute petite application
+            <a href="https://struts.apache.org/index.html" target="_blank">Struts 2</a>
+            à expérimenter en déploiement sur
+            <a href="https://azure.microsoft.com/en-ca/overview/what-is-azure/" target="_blank">Azure</a>.
+        </p>
 
-    <br />
-    <p><a href="<s:url action='hello'/>">Bonjour!</a></p>
+        <c:set var="sha" scope="page" value="${System.getenv('GITHUB_SHA')}"/>
+        <c:if test="${sha != null}">
+            <c:set var="shaUrl" scope="page" value="https://github.com/cds-snc/az-struts/commit/${sha}"/>
+            <p>Dernière commit: <a href="<c:url value="${shaUrl}" />" target="_blank"><c:out value="${sha}"/></a></p>
+        </c:if>
 
-    <s:url action="hello" var="helloNancy">
-      <s:param name="name">Nancy</s:param>
-    </s:url>
+        <br />
+        <p><a href="<s:url action='hello'/>">Bonjour!</a></p>
 
-    <p><a href="${helloNancy}">Bonjour Nancy!</a></p>
-  </body>
-</html>
+        <s:url action="hello" var="helloNancy">
+          <s:param name="name">Nancy</s:param>
+        </s:url>
+
+        <p><a href="${helloNancy}">Bonjour Nancy!</a></p>
+
+    </jsp:body>
+</t:wrapper>

--- a/src/main/webapp/index.jsp
+++ b/src/main/webapp/index.jsp
@@ -16,7 +16,7 @@
         <c:set var="sha" scope="page" value="${System.getenv('GITHUB_SHA')}"/>
         <c:if test="${sha != null}">
             <c:set var="shaUrl" scope="page" value="https://github.com/cds-snc/az-struts/commit/${sha}"/>
-            <p>Dernière commit: <a href="<c:url value="${shaUrl}" />" target="_blank"><c:out value="${sha}"/></a></p>
+            <p>Dernier commit: <a href="<c:url value="${shaUrl}" />" target="_blank"><c:out value="${sha}"/></a></p>
         </c:if>
 
         <br />


### PR DESCRIPTION
This way, we will have common header code shared across files.
This means we can throw some CSS in here, as well as some common `<meta>` tags into the header of all our pages.

Heavily indebted to this stackoverflow answer:
- https://stackoverflow.com/questions/1296235/jsp-tricks-to-make-templating-easier

***

Also ran an [axe scan](https://www.deque.com/axe/) on my pages and made a few small fixes:

- added a `lang` attribute to the HTML
- added `<main>` tags to body content